### PR TITLE
Gitea-dr

### DIFF
--- a/system/argocd/values.yaml
+++ b/system/argocd/values.yaml
@@ -70,7 +70,7 @@ argocd-apps:
       generators:
         - git:
             # TODO:
-            repoURL: &repoURL http://gitea-http.gitea:3000/ops/homelab2
+            repoURL: &repoURL https://github.com/east4ming/homelab2
             revision: &revision master
             directories:
               - path: system/*


### PR DESCRIPTION
- 将 Argo CD 的 repoURL 从本地 Gitea 仓库更改为 GitHub 仓库
- 使用 HTTPS 协议替代 HTTP 协议，提高安全性