### PR TITLE
Gitea-dr

### DIFF
--- a/platform/gitea/Chart.yaml
+++ b/platform/gitea/Chart.yaml
@@ -3,5 +3,5 @@ name: gitea
 version: 0.0.0
 dependencies:
   - name: gitea
-    version: 11.0.1
+    version: 12.0.0
     repository: https://dl.gitea.io/charts/

--- a/platform/gitea/values.yaml
+++ b/platform/gitea/values.yaml
@@ -48,7 +48,23 @@ gitea:
         ALLOWED_DOMAINS: ""
         ALLOW_LOCALNETWORKS: true
         BLOCKED_DOMAINS: ""
+      database:
+        DB_TYPE: sqlite3
+      session:
+        PROVIDER: memory
+      cache:
+        ADAPTER: memory
+      queue:
+        TYPE: level
     metrics:
       enabled: true
       serviceMonitor:
         enabled: true
+  valkey-cluster:
+    enabled: false
+  valkey:
+    enabled: false
+  postgresql-ha:
+    enabled: false
+  postgresql:
+    enabled: false


### PR DESCRIPTION
- 将 Gitea 版本从 11.0.1 升级到 12.0.0
- 添加数据库、会话、缓存和队列的配置
- 禁用 valkey-cluster、valkey、postgresql-ha 和 postgresql