### PR TITLE
docs: remove Knative from the roadmap

### DIFF
--- a/docs/reference/roadmap.md
+++ b/docs/reference/roadmap.md
@@ -85,6 +85,5 @@ Nice to have
 - [ ] Air-gap install
 - [ ] Automated testing
 - [ ] Security audit
-- [ ] Serverless ([Knative](https://knative.dev))
 - [ ] Cluster API ([last attempt](https://github.com/khuedoan/homelab/pull/2))
 - [ ] Split DNS (requires a better router)


### PR DESCRIPTION
I abandoned the Knative idea because for most (if not all) of my personal projects, they are better served with traditional HPA + Deployment and the like, because most of them are written in Rust/Go, which only use a tiny amount of resources, so the value of scale to zero is minimal.

Related  issue https://github.com/khuedoan/homelab/issues/86